### PR TITLE
Rails/Present-20250829014756

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,7 +70,6 @@ Rails/BulkChangeTable:
   Exclude:
     - 'db/migrate/20250701140834_devise_create_users.rb'
 
-
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowOnlyRestArgument, UseAnonymousForwarding, RedundantRestArgumentNames, RedundantKeywordRestArgumentNames, RedundantBlockArgumentNames.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,12 +70,6 @@ Rails/BulkChangeTable:
   Exclude:
     - 'db/migrate/20250701140834_devise_create_users.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: NotNilAndNotEmpty, NotBlank, UnlessBlank.
-Rails/Present:
-  Exclude:
-    - 'bin/bundle'
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).

--- a/bin/bundle
+++ b/bin/bundle
@@ -39,7 +39,7 @@ m = Module.new do
 
   def gemfile
     gemfile = ENV['BUNDLE_GEMFILE']
-    return gemfile if gemfile && !gemfile.empty?
+    return gemfile if gemfile.present?
 
     File.expand_path('../Gemfile', __dir__)
   end


### PR DESCRIPTION
# Rubocop challenge!

[Rails/Present](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Rails/Present)

**Safe autocorrect: Yes**
:white_check_mark: The autocorrect a cop does is safe (equivalent) by design.

## Description

> ### Overview
>
> Checks for code that can be written with simpler conditionals
> using `Object#present?` defined by Active Support.
>
> Interaction with `Style/UnlessElse`:
> The configuration of `NotBlank` will not produce an offense in the
> context of `unless else` if `Style/UnlessElse` is enabled. This is
> to prevent interference between the autocorrection of the two cops.
>
> ### Examples
>
> #### NotNilAndNotEmpty: true (default)
>
> ```rb
> # Converts usages of `!nil? && !empty?` to `present?`
>
> # bad
> !foo.nil? && !foo.empty?
>
> # bad
> foo != nil && !foo.empty?
>
> # good
> foo.present?
> ```
>
> #### NotBlank: true (default)
>
> ```rb
> # Converts usages of `!blank?` to `present?`
>
> # bad
> !foo.blank?
>
> # bad
> not foo.blank?
>
> # good
> foo.present?
> ```
>
> #### UnlessBlank: true (default)
>
> ```rb
> # Converts usages of `unless blank?` to `if present?`
>
> # bad
> something unless foo.blank?
>
> # good
> something if foo.present?
> ```

Auto generated by [rubocop_challenger](https://github.com/ryz310/rubocop_challenger)
