### PR TITLE
Style/SpecialGlobalVars-20250913094737

### DIFF
--- a/.rubocop_challenge.yml
+++ b/.rubocop_challenge.yml
@@ -1,0 +1,3 @@
+---
+Ignore:
+- Style/SpecialGlobalVars

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -141,6 +141,12 @@ Style/IfUnlessModifier:
   Exclude:
     - 'bin/bundle'
 
+# Offense count: 1
+# This cop supports unsafe autocorrection (--autocorrect-all).
+# Configuration parameters: RequireEnglish.
+# SupportedStyles: use_perl_names, use_english_names, use_builtin_english_names
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_perl_names
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -141,12 +141,6 @@ Style/IfUnlessModifier:
   Exclude:
     - 'bin/bundle'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: RequireEnglish.
-# SupportedStyles: use_perl_names, use_english_names, use_builtin_english_names
-Style/SpecialGlobalVars:
-  EnforcedStyle: use_perl_names
 
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).


### PR DESCRIPTION
# Rubocop challenge!

[Style/SpecialGlobalVars](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SpecialGlobalVars)

**Safe autocorrect: No**
:warning: The autocorrect a cop can yield false positives by design.

## Description

> ### Overview
>
> Looks for uses of Perl-style global variables.
> Correcting to global variables in the 'English' library
> will add a require statement to the top of the file if
> enabled by RequireEnglish config.
>
> ### Examples
>
> #### EnforcedStyle: use_english_names (default)
>
> ```rb
> # good
> require 'English' # or this could be in another file.
>
> puts $LOAD_PATH
> puts $LOADED_FEATURES
> puts $PROGRAM_NAME
> puts $ERROR_INFO
> puts $ERROR_POSITION
> puts $FIELD_SEPARATOR # or $FS
> puts $OUTPUT_FIELD_SEPARATOR # or $OFS
> puts $INPUT_RECORD_SEPARATOR # or $RS
> puts $OUTPUT_RECORD_SEPARATOR # or $ORS
> puts $INPUT_LINE_NUMBER # or $NR
> puts $LAST_READ_LINE
> puts $DEFAULT_OUTPUT
> puts $DEFAULT_INPUT
> puts $PROCESS_ID # or $PID
> puts $CHILD_STATUS
> puts $LAST_MATCH_INFO
> puts $IGNORECASE
> puts $ARGV # or ARGV
> ```
>
> #### EnforcedStyle: use_perl_names
>
> ```rb
> # good
> puts $:
> puts $"
> puts $0
> puts $!
> puts $@
> puts $;
> puts $,
> puts $/
> puts $\
> puts $.
> puts $_
> puts $>
> puts $<
> puts $$
> puts $?
> puts $~
> puts $=
> puts $*
> ```
>
> #### EnforcedStyle: use_builtin_english_names
>
> ```rb
>
> # good
> # Like `use_perl_names` but allows builtin global vars.
> puts $LOAD_PATH
> puts $LOADED_FEATURES
> puts $PROGRAM_NAME
> puts ARGV
> puts $:
> puts $"
> puts $0
> puts $!
> puts $@
> puts $;
> puts $,
> puts $/
> puts $\
> puts $.
> puts $_
> puts $>
> puts $<
> puts $$
> puts $?
> puts $~
> puts $=
> puts $*
> ```

Auto generated by [rubocop_challenger](https://github.com/ryz310/rubocop_challenger)
