### PR TITLE
Style/SymbolArray-20250913150649

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -140,11 +140,3 @@ Style/GlobalStdStream:
 Style/IfUnlessModifier:
   Exclude:
     - 'bin/bundle'
-
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: .
-# SupportedStyles: percent, brackets
-Style/SymbolArray:
-  EnforcedStyle: percent
-  MinSize: 13

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -3,6 +3,6 @@
 # Configure parameters to be partially matched (e.g. passw matches password) and filtered from the log file.
 # Use this to limit dissemination of sensitive information.
 # See the ActiveSupport::ParameterFilter documentation for supported notations and behaviors.
-Rails.application.config.filter_parameters += [
-  :passw, :email, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn, :cvv, :cvc
+Rails.application.config.filter_parameters += %i[
+  passw email secret token _key crypt salt certificate otp ssn cvv cvc
 ]


### PR DESCRIPTION
# Rubocop challenge!

[Style/SymbolArray](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/SymbolArray)

**Safe autocorrect: Yes**
:white_check_mark: The autocorrect a cop does is safe (equivalent) by design.

## Description

> ### Overview
>
> Checks for array literals made up of symbols that are not
> using the %i() syntax.
>
> Alternatively, it checks for symbol arrays using the %i() syntax on
> projects which do not want to use that syntax, perhaps because they
> support a version of Ruby lower than 2.0.
>
> Configuration option: MinSize
> If set, arrays with fewer elements than this value will not trigger the
> cop. For example, a `MinSize` of `3` will not enforce a style on an
> array of 2 or fewer elements.
>
> ### Examples
>
> #### EnforcedStyle: percent (default)
>
> ```rb
> # good
> %i[foo bar baz]
>
> # bad
> [:foo, :bar, :baz]
>
> # bad (contains spaces)
> %i[foo\ bar baz\ quux]
>
> # bad (contains [] with spaces)
> %i[foo \[ \]]
>
> # bad (contains () with spaces)
> %i(foo \( \))
> ```
>
> #### EnforcedStyle: brackets
>
> ```rb
> # good
> [:foo, :bar, :baz]
>
> # bad
> %i[foo bar baz]
> ```

Auto generated by [rubocop_challenger](https://github.com/ryz310/rubocop_challenger)
