### PR TITLE
Style/ArgumentsForwarding-20250926014517

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -64,7 +64,6 @@ Rails/BulkChangeTable:
   Exclude:
     - 'db/migrate/20250701140834_devise_create_users.rb'
 
-
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedVars, DefaultToNil.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -64,15 +64,6 @@ Rails/BulkChangeTable:
   Exclude:
     - 'db/migrate/20250701140834_devise_create_users.rb'
 
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowOnlyRestArgument, UseAnonymousForwarding, RedundantRestArgumentNames, RedundantKeywordRestArgumentNames, RedundantBlockArgumentNames.
-# RedundantRestArgumentNames: args, arguments
-# RedundantKeywordRestArgumentNames: kwargs, options, opts
-# RedundantBlockArgumentNames: blk, block, proc
-Style/ArgumentsForwarding:
-  Exclude:
-    - 'bin/setup'
 
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).

--- a/bin/setup
+++ b/bin/setup
@@ -3,8 +3,8 @@ require 'fileutils'
 
 APP_ROOT = File.expand_path('..', __dir__)
 
-def system!(*args)
-  system(*args, exception: true)
+def system!(*)
+  system(*, exception: true)
 end
 
 FileUtils.chdir APP_ROOT do


### PR DESCRIPTION
# Rubocop challenge!

[Style/ArgumentsForwarding](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ArgumentsForwarding)

**Safe autocorrect: Yes**
:white_check_mark: The autocorrect a cop does is safe (equivalent) by design.

## Description

> ### Overview
>
> In Ruby 2.7, arguments forwarding has been added.
>
> This cop identifies places where `do_something(*args, &block)`
> can be replaced by `do_something(...)`.
>
> In Ruby 3.1, anonymous block forwarding has been added.
>
> This cop identifies places where `do_something(&block)` can be replaced
> by `do_something(&)`; if desired, this functionality can be disabled
> by setting `UseAnonymousForwarding: false`.
>
> In Ruby 3.2, anonymous args/kwargs forwarding has been added.
>
> This cop also identifies places where `+use_args(*args)+`/`+use_kwargs(**kwargs)+` can be
> replaced by `+use_args(*)+`/`+use_kwargs(**)+`; if desired, this functionality can be
> disabled by setting `UseAnonymousForwarding: false`.
>
> And this cop has `RedundantRestArgumentNames`, `RedundantKeywordRestArgumentNames`,
> and `RedundantBlockArgumentNames` options. This configuration is a list of redundant names
> that are sufficient for anonymizing meaningless naming.
>
> Meaningless names that are commonly used can be anonymized by default:
> e.g., `+*args+`, `+**options+`, `&block`, and so on.
>
> Names not on this list are likely to be meaningful and are allowed by default.
>
> This cop handles not only method forwarding but also forwarding to `super`.
>
> [NOTE]
> ====
> Because of a bug in Ruby 3.3.0, when a block is referenced inside of another block,
> no offense will be registered until Ruby 3.4:
>
> [source,ruby]
> ----
> def foo(&block)
>   # Using an anonymous block would be a syntax error on Ruby 3.3.0
>   block_method { bar(&block) }
> end
> ----
> ====
>
> ### Examples
>
> ```rb
> # bad
> def foo(*args, &block)
>   bar(*args, &block)
> end
>
> # bad
> def foo(*args, **kwargs, &block)
>   bar(*args, **kwargs, &block)
> end
>
> # good
> def foo(...)
>   bar(...)
> end
> ```
>
> #### UseAnonymousForwarding: true (default, only relevant for Ruby >= 3.2)
>
> ```rb
> # bad
> def foo(*args, **kwargs, &block)
>   args_only(*args)
>   kwargs_only(**kwargs)
>   block_only(&block)
> end
>
> # good
> def foo(*, **, &)
>   args_only(*)
>   kwargs_only(**)
>   block_only(&)
> end
> ```
>
> #### UseAnonymousForwarding: false (only relevant for Ruby >= 3.2)
>
> ```rb
> # good
> def foo(*args, **kwargs, &block)
>   args_only(*args)
>   kwargs_only(**kwargs)
>   block_only(&block)
> end
> ```
>
> #### AllowOnlyRestArgument: true (default, only relevant for Ruby < 3.2)
>
> ```rb
> # good
> def foo(*args)
>   bar(*args)
> end
>
> def foo(**kwargs)
>   bar(**kwargs)
> end
> ```
>
> #### AllowOnlyRestArgument: false (only relevant for Ruby < 3.2)
>
> ```rb
> # bad
> # The following code can replace the arguments with `...`,
> # but it will change the behavior. Because `...` forwards block also.
> def foo(*args)
>   bar(*args)
> end
>
> def foo(**kwargs)
>   bar(**kwargs)
> end
> ```
>
> #### RedundantRestArgumentNames: ['args', 'arguments'] (default)
>
> ```rb
> # bad
> def foo(*args)
>   bar(*args)
> end
>
> # good
> def foo(*)
>   bar(*)
> end
> ```
>
> #### RedundantKeywordRestArgumentNames: ['kwargs', 'options', 'opts'] (default)
>
> ```rb
> # bad
> def foo(**kwargs)
>   bar(**kwargs)
> end
>
> # good
> def foo(**)
>   bar(**)
> end
> ```
>
> #### RedundantBlockArgumentNames: ['blk', 'block', 'proc'] (default)
>
> ```rb
> # bad - But it is good with `EnforcedStyle: explicit` set for `Naming/BlockForwarding`.
> def foo(&block)
>   bar(&block)
> end
>
> # good
> def foo(&)
>   bar(&)
> end
> ```

Auto generated by [rubocop_challenger](https://github.com/ryz310/rubocop_challenger)
