### PR TITLE
Style/FetchEnvVar-20251003014322

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -64,7 +64,6 @@ Rails/BulkChangeTable:
   Exclude:
     - 'db/migrate/20250701140834_devise_create_users.rb'
 
-
 # Offense count: 34
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: EnforcedStyle.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -64,12 +64,6 @@ Rails/BulkChangeTable:
   Exclude:
     - 'db/migrate/20250701140834_devise_create_users.rb'
 
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowedVars, DefaultToNil.
-Style/FetchEnvVar:
-  Exclude:
-    - 'bin/bundle'
 
 # Offense count: 34
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/bin/bundle
+++ b/bin/bundle
@@ -18,7 +18,7 @@ m = Module.new do
   end
 
   def env_var_version
-    ENV['BUNDLER_VERSION']
+    ENV.fetch('BUNDLER_VERSION', nil)
   end
 
   def cli_arg_version
@@ -38,7 +38,7 @@ m = Module.new do
   end
 
   def gemfile
-    gemfile = ENV['BUNDLE_GEMFILE']
+    gemfile = ENV.fetch('BUNDLE_GEMFILE', nil)
     return gemfile if gemfile && !gemfile.empty?
 
     File.expand_path('../Gemfile', __dir__)


### PR DESCRIPTION
# Rubocop challenge!

[Style/FetchEnvVar](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FetchEnvVar)

**Safe autocorrect: Yes**
:white_check_mark: The autocorrect a cop does is safe (equivalent) by design.

## Description

> ### Overview
>
> Suggests `ENV.fetch` for the replacement of `ENV[]`.
> `ENV[]` silently fails and returns `nil` when the environment variable is unset,
> which may cause unexpected behaviors when the developer forgets to set it.
> On the other hand, `ENV.fetch` raises `KeyError` or returns the explicitly
> specified default value.
>
> ### Examples
>
> #### DefaultToNil: true (default)
>
> ```rb
> # bad
> ENV['X']
> x = ENV['X']
>
> # good
> ENV.fetch('X', nil)
> x = ENV.fetch('X', nil)
>
> # also good
> !ENV['X']
> ENV['X'].some_method # (e.g. `.nil?`)
> ```
>
> #### DefaultToNil: false
>
> ```rb
> # bad
> ENV['X']
> x = ENV['X']
>
> # good
> ENV.fetch('X')
> x = ENV.fetch('X')
>
> # also good
> !ENV['X']
> ENV['X'].some_method # (e.g. `.nil?`)
> ```

Auto generated by [rubocop_challenger](https://github.com/ryz310/rubocop_challenger)
